### PR TITLE
Autofocus Addr/TX Input Field

### DIFF
--- a/src/Update.elm
+++ b/src/Update.elm
@@ -2336,7 +2336,7 @@ updateByUrl plugins uc url model =
                                     |> s_searchType
                                         (Search.initSearchAddressAndTxs Nothing)
                           }
-                        , []
+                        , [ Browser.Dom.focus Search.searchInputId |> Task.attempt (\_ -> NoOp) |> CmdEffect ]
                         )
 
                     Route.Stats ->


### PR DESCRIPTION
There is only one text input field at the starting page, would be nice to autofocus this, such that if one wants to quickly look up a copied hash no mouse input is required.